### PR TITLE
Replace deprecated `ugettext_lazy` with `gettext_lazy`.

### DIFF
--- a/ideas_bugs/models.py
+++ b/ideas_bugs/models.py
@@ -2,7 +2,7 @@ from django.conf import settings
 from django.db import models
 from django.db.models.signals import post_save
 from django.dispatch import receiver
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from backend.mixins import TimeStampMixin, UUIDMixin, VoteMixin
 from ideas_bugs.utils import save_history, save_idea_or_bug
 from talent.models import Person

--- a/talent/models.py
+++ b/talent/models.py
@@ -6,7 +6,7 @@ from django.core.exceptions import ValidationError
 from django.db import models
 from django.db.models.signals import post_save
 from django.dispatch import receiver
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from entitlements.exceptions import ValidationError as ValidError
 from backend.mixins import TimeStampMixin, UUIDMixin
 


### PR DESCRIPTION
So reduce warnings seen when running pytest, such as:
RemovedInDjango40Warning: django.utils.translation.ugettext_lazy() is deprecated in favor of django.utils.translation.gettext_lazy().