### PR TITLE
task 87 depend on blocked tasks

### DIFF
--- a/api/utils.py
+++ b/api/utils.py
@@ -23,10 +23,10 @@ def get_current_user(info, input):
 def get_current_person(info, input_data=None):
     user = info.context.user
 
-    if input_data:
-        user_id = input_data.get("user_id", None)  
-    elif settings.FAKE_LOGIN_USER_ID:
+    if settings.FAKE_LOGIN_USER_ID:
         user_id = settings.FAKE_LOGIN_USER_ID
+    elif input_data:
+        user_id = input_data.get("user_id", None)  
     else:
         user_id = None
 

--- a/work/models.py
+++ b/work/models.py
@@ -525,7 +525,7 @@ class TaskListing(models.Model):
         if statuses:
             filter_data["status__in"] = statuses
 
-        if Task.TASK_STATUS_AVAILABLE in statuses:
+        if Task.TASK_STATUS_AVAILABLE in statuses and Task.TASK_STATUS_BLOCKED not in statuses:
             filter_data["has_active_depends"] = False
 
         if tags:


### PR DESCRIPTION
Allow selecting a blocked task as a dependency of another task

**WARNING**: We modified get_current_person so it checks first the fake login user id. It makes sense to us that FAKE_LOGIN_USER_ID has priority over the other ids, also it was a **NECESSARY CHANGE** to make it work in the local environment